### PR TITLE
Update network models, added bidirectional substations Wp3

### DIFF
--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/BaseClasses/Storage_controlled_base.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/BaseClasses/Storage_controlled_base.mo
@@ -1,0 +1,120 @@
+within IBPSAdestest.Consumer.BaseClasses;
+partial model Storage_controlled_base
+  "Partial model of a component with only one fluid port and an ideal sink. No return is modelled."
+  extends PartialConsumer;
+
+  parameter Modelica.SIunits.Temperature T_sup
+    "Supply temperature cooling";
+
+  parameter Modelica.SIunits.Temperature T_ret
+    "Supply temperature cooling";
+
+  parameter Modelica.SIunits.HeatFlowRate Q_nominal=10000
+    "Nominal heat or cool flow";
+
+  parameter Modelica.SIunits.Volume volume_tank
+    "Volume of the water storage tank";
+
+  parameter Boolean external_control=false
+    "Enable external control";
+
+
+  Modelica.Fluid.Interfaces.FluidPort_a port_a(redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-110,30},{-90,50}})));
+  Modelica.Fluid.Interfaces.FluidPort_b port_b(redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-110,-52},{-90,-32}})));
+  IBPSA.Fluid.Storage.Stratified tan(
+    hTan=2,
+    dIns=0.3,
+    nSeg=3,
+    tau=20,
+    VTan=volume_tank,
+    redeclare package Medium = Medium,
+    T_start=T_sup,
+    m_flow_nominal=abs(Q_nominal/((T_sup - T_ret)*4.182)))
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  IBPSA.Fluid.Movers.FlowControlled_m_flow pum_stor(
+    addPowerToMedium=false,
+    redeclare package Medium = Medium,
+    use_inputFilter=false,
+    T_start=T_sup,
+    m_flow_nominal=abs(Q_nominal/((T_sup - T_ret)*4.182)))
+    annotation (Placement(transformation(extent={{-80,50},{-60,30}})));
+  IBPSA.Fluid.Movers.FlowControlled_m_flow pum_demand(
+    addPowerToMedium=false,
+    redeclare package Medium = Medium,
+    use_inputFilter=false,
+    T_start=T_sup,
+    m_flow_nominal=abs(Q_nominal/((T_sup - T_ret)*4.182)))
+    annotation (Placement(transformation(extent={{32,50},{52,30}})));
+  Modelica.Blocks.Interfaces.RealInput QDem "Control input" annotation (
+      Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={0,100})));
+  Modelica.Blocks.Math.Division division annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={72,40})));
+  Modelica.Blocks.Sources.RealExpression cp_dt(y=abs((T_sup - T_ret)*cp_default))
+    annotation (Placement(transformation(extent={{8,50},{28,70}})));
+  IBPSA.Fluid.HeatExchangers.HeaterCooler_u hea(Q_flow_nominal=-1,
+    dp_nominal=0,
+    redeclare package Medium = Medium,
+    T_start=T_sup,
+    m_flow_nominal=abs(Q_nominal/((T_sup - T_ret)*4.182)))         annotation (
+      Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=-90,
+        origin={60,-2})));
+  Modelica.Blocks.Interfaces.RealInput Control_m_flow "Control input"
+    annotation (Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={-30,100})));
+  Modelica.Blocks.Logical.Switch switch1
+    annotation (Placement(transformation(extent={{-40,0},{-60,20}})));
+  Modelica.Blocks.Sources.BooleanExpression booleanExpression(y=
+        external_control)
+    annotation (Placement(transformation(extent={{-12,0},{-32,22}})));
+  Modelica.Blocks.Interfaces.RealOutput storage_state annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-60,100})));
+  Modelica.Blocks.Sources.RealExpression realExpression(y=(((tan.heaPorVol[1].T +
+        tan.heaPorVol[2].T + tan.heaPorVol[3].T)/3) - T_ret)/(T_sup - T_ret))
+    annotation (Placement(transformation(extent={{-94,70},{-74,90}})));
+  IBPSA.Fluid.Sources.Boundary_pT bou(nPorts=1, redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-100,52},{-80,72}})));
+equation
+  connect(pum_stor.port_a, port_a)
+    annotation (Line(points={{-80,40},{-100,40}}, color={0,127,255}));
+  connect(QDem, division.u1) annotation (Line(points={{0,100},{0,76},{78,76},{78,
+          52}}, color={0,0,127}));
+  connect(cp_dt.y, division.u2)
+    annotation (Line(points={{29,60},{66,60},{66,52}}, color={0,0,127}));
+  connect(hea.port_a, pum_demand.port_b)
+    annotation (Line(points={{60,8},{60,40},{52,40}}, color={0,127,255}));
+  connect(division.y, pum_demand.m_flow_in) annotation (Line(points={{72,29},{72,
+          20},{42,20},{42,28}}, color={0,0,127}));
+  connect(QDem, hea.u) annotation (Line(points={{0,100},{0,16},{66,16},{66,10}},
+        color={0,0,127}));
+  connect(switch1.y, pum_stor.m_flow_in)
+    annotation (Line(points={{-61,10},{-70,10},{-70,28}}, color={0,0,127}));
+  connect(switch1.u1, Control_m_flow)
+    annotation (Line(points={{-38,18},{-30,18},{-30,100}}, color={0,0,127}));
+  connect(division.y, switch1.u3) annotation (Line(points={{72,29},{72,-54},{-30,
+          -54},{-30,2},{-38,2}}, color={0,0,127}));
+  connect(switch1.u2, booleanExpression.y) annotation (Line(points={{-38,10},{-36,
+          10},{-36,11},{-33,11}}, color={255,0,255}));
+  connect(realExpression.y, storage_state)
+    annotation (Line(points={{-73,80},{-60,80},{-60,100}}, color={0,0,127}));
+  connect(pum_stor.port_a, bou.ports[1])
+    annotation (Line(points={{-80,40},{-80,62}}, color={0,127,255}));
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)));
+end Storage_controlled_base;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/BaseClasses/Storage_controlled_cooling.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/BaseClasses/Storage_controlled_cooling.mo
@@ -1,0 +1,13 @@
+within IBPSAdestest.Consumer.BaseClasses;
+model Storage_controlled_cooling
+  extends Storage_controlled_base(hea(Q_flow_nominal=1));
+equation
+  connect(tan.port_b, pum_stor.port_b) annotation (Line(points={{10,0},{10,-40},
+          {-20,-40},{-20,40},{-60,40}}, color={0,127,255}));
+  connect(port_b, tan.port_a) annotation (Line(points={{-100,-42},{-10,-42},{
+          -10,0}}, color={0,127,255}));
+  connect(tan.port_b, pum_demand.port_a) annotation (Line(points={{10,0},{18,0},
+          {18,40},{32,40}}, color={0,127,255}));
+  connect(hea.port_b, tan.port_a) annotation (Line(points={{60,-12},{60,-40},{
+          28,-40},{28,12},{-10,12},{-10,0}}, color={0,127,255}));
+end Storage_controlled_cooling;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/BaseClasses/Storage_controlled_heating.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/BaseClasses/Storage_controlled_heating.mo
@@ -1,0 +1,13 @@
+within IBPSAdestest.Consumer.BaseClasses;
+model Storage_controlled_heating
+  extends Storage_controlled_base;
+equation
+  connect(pum_stor.port_b, tan.port_a)
+    annotation (Line(points={{-60,40},{-10,40},{-10,0}}, color={0,127,255}));
+  connect(pum_demand.port_a, tan.port_a)
+    annotation (Line(points={{32,40},{-10,40},{-10,0}}, color={0,127,255}));
+  connect(hea.port_b, tan.port_b) annotation (Line(points={{60,-12},{60,-42},{
+          10,-42},{10,0}}, color={0,127,255}));
+  connect(port_b, tan.port_b)
+    annotation (Line(points={{-100,-42},{10,-42},{10,0}}, color={0,127,255}));
+end Storage_controlled_heating;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/BaseClasses/package.order
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/BaseClasses/package.order
@@ -3,3 +3,6 @@ EndNode_twoport
 PartialConsumer
 TwinConsumer
 SimpleConsumer
+Storage_controlled_base
+Storage_controlled_heating
+Storage_controlled_cooling

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/ConsumerBidirectional.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/ConsumerBidirectional.mo
@@ -1,0 +1,304 @@
+﻿within IBPSAdestest.Consumer;
+model ConsumerBidirectional
+  "Basic consumer model for DesTest with a fixed temperature drop, decentralized pump and ideal mass flow control"
+  extends IBPSAdestest.Consumer.BaseClasses.EndNode_twoport;
+
+  parameter Modelica.SIunits.TemperatureDifference deltaT=4
+    "Desired temperature difference between warm and cold temperature line";
+
+  parameter Modelica.SIunits.Temperature T_sup_coo=273.15+10
+    "Supply temperature cooling (building side)";
+
+  parameter Modelica.SIunits.Temperature T_ret_coo=273.15+15
+    "Return temperature cooling (building side)";
+
+  parameter Modelica.SIunits.Temperature T_sup_hea=273.15+35
+    "Supply temperature heating (building side)";
+
+  parameter Modelica.SIunits.Temperature T_ret_hea=273.15+25
+    "Return temperature heating (building side)";
+
+  parameter Real eta_chi=0.3
+    "Carnot efficiency chiller";
+
+  parameter Real eta_hea=0.3
+    "Carnot efficiency heat pump";
+
+  parameter Modelica.SIunits.HeatFlowRate Q_hea_nominal=10000
+    "Nominal heat flow for heating";
+
+  parameter Modelica.SIunits.HeatFlowRate Q_coo_nominal=10000
+    "Nominal heat flow for cooling (positive)";
+
+  parameter Modelica.SIunits.Pressure dp_nominal(displayUnit="Pa")=10000
+    "Pressure difference at nominal flow rate (for each flow leg)";
+
+  Modelica.Blocks.Interfaces.RealInput HDem "Control input" annotation (
+      Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={0,100})));
+
+  Modelica.Blocks.Interfaces.RealInput CDem "Control input" annotation (
+      Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={40,100})));
+  IBPSA.Fluid.Movers.FlowControlled_m_flow pum_hea(
+                                               redeclare package Medium =
+        Medium,
+    m_flow_nominal=Q_hea_nominal/(deltaT*cp_default),
+    addPowerToMedium=false,
+    use_inputFilter=false,
+    T_start=289.15)
+    annotation (Placement(transformation(extent={{-44,2},{-24,-18}})));
+  IBPSA.Fluid.Movers.FlowControlled_m_flow pumcoo(
+                                               redeclare package Medium =
+        Medium,
+    addPowerToMedium=false,
+    use_inputFilter=false,
+    m_flow_nominal=-Q_coo_nominal/(deltaT*cp_default),
+    T_start=285.15)
+    annotation (Placement(transformation(extent={{-60,-90},{-40,-110}})));
+  IBPSA.Fluid.HeatPumps.Carnot_TCon heaPum(
+    redeclare package Medium1 = Medium,
+    redeclare package Medium2 = Medium,
+    etaCarnot_nominal=eta_hea,
+    QCon_flow_nominal=Q_hea_nominal,
+    dTEva_nominal=-deltaT,
+    dp1_nominal=dp_nominal,
+    dp2_nominal=dp_nominal,
+    dTCon_nominal=T_sup_hea - T_ret_hea,
+    T2_start=285.15)
+    annotation (Placement(transformation(extent={{44,-12},{24,8}})));
+  IBPSA.Fluid.Chillers.Carnot_TEva chi(
+    redeclare package Medium1 = Medium,
+    redeclare package Medium2 = Medium,
+    etaCarnot_nominal=eta_chi,
+    QEva_flow_nominal=Q_coo_nominal,
+    dTEva_nominal=T_sup_coo - T_ret_coo,
+    dTCon_nominal=deltaT,
+    dp1_nominal=dp_nominal,
+    dp2_nominal=dp_nominal,
+    T1_start=289.15)
+    annotation (Placement(transformation(extent={{26,-116},{46,-96}})));
+  IBPSA.Fluid.Sources.MassFlowSource_T boundary(nPorts=1,
+    T=T_ret_hea,
+    use_m_flow_in=true,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{86,14},{66,34}})));
+  IBPSA.Fluid.Sources.FixedBoundary bou(nPorts=1, redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-18,14},{2,34}})));
+  IBPSA.Fluid.Sources.MassFlowSource_T boundary1(nPorts=1,
+    use_m_flow_in=true,
+    T=T_ret_coo,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{84,-136},{64,-116}})));
+  IBPSA.Fluid.Sources.FixedBoundary bou1(nPorts=1, redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-16,-136},{4,-116}})));
+  Modelica.Blocks.Sources.RealExpression realExpression(y=T_sup_hea)
+    annotation (Placement(transformation(extent={{86,-4},{66,16}})));
+  Modelica.Blocks.Sources.RealExpression realExpression1(y=T_sup_coo)
+    annotation (Placement(transformation(extent={{-8,-104},{12,-84}})));
+  Modelica.Blocks.Sources.RealExpression realExpression2(y=cp_default*(
+        T_sup_hea - T_ret_hea))
+    annotation (Placement(transformation(extent={{0,38},{20,58}})));
+  Modelica.Blocks.Math.Division division
+    annotation (Placement(transformation(extent={{32,44},{52,66}})));
+  Modelica.Blocks.Math.Division division1
+    annotation (Placement(transformation(extent={{34,-168},{54,-146}})));
+  Modelica.Blocks.Sources.RealExpression realExpression3(y=-cp_default*(
+        T_sup_coo - T_ret_coo))
+    annotation (Placement(transformation(extent={{2,-174},{22,-154}})));
+  Modelica.Blocks.Math.Division division2
+    annotation (Placement(transformation(extent={{8,-38},{-12,-16}})));
+  Modelica.Blocks.Sources.RealExpression realExpression5(y=-cp_default*(deltaT))
+    annotation (Placement(transformation(extent={{44,-44},{24,-24}})));
+  Modelica.Blocks.Math.Division division3
+    annotation (Placement(transformation(extent={{-58,-172},{-78,-150}})));
+  Modelica.Blocks.Sources.RealExpression realExpression7(y=cp_default*(deltaT))
+    annotation (Placement(transformation(extent={{-16,-178},{-36,-158}})));
+  Modelica.Blocks.Interfaces.RealOutput P annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-36,100})));
+  Modelica.Blocks.Math.Sum sum1(nin=4)
+    annotation (Placement(transformation(extent={{-60,60},{-40,80}})));
+  Modelica.Fluid.Sensors.TemperatureTwoPort temperature_cold(redeclare package
+      Medium = Medium)
+    annotation (Placement(transformation(extent={{72,-52},{52,-32}})));
+  Modelica.Fluid.Sensors.TemperatureTwoPort temperature_warm(redeclare package
+      Medium = Medium)
+    annotation (Placement(transformation(extent={{64,-110},{84,-90}})));
+equation
+  connect(heaPum.port_a2, pum_hea.port_b)
+    annotation (Line(points={{24,-8},{-24,-8}}, color={0,127,255}));
+  connect(pum_hea.port_a, port_a) annotation (Line(points={{-44,-8},{-80,-8},{-80,
+          40},{-100,40}}, color={0,127,255}));
+  connect(port_b, pumcoo.port_a) annotation (Line(points={{-100,-42},{-88,-42},{
+          -88,-100},{-60,-100}}, color={0,127,255}));
+  connect(pumcoo.port_b, chi.port_a1)
+    annotation (Line(points={{-40,-100},{26,-100}}, color={0,127,255}));
+  connect(heaPum.port_a1, boundary.ports[1]) annotation (Line(points={{44,4},{58,
+          4},{58,24},{66,24}}, color={0,127,255}));
+  connect(heaPum.port_b1, bou.ports[1]) annotation (Line(points={{24,4},{10,4},{
+          10,24},{2,24}}, color={0,127,255}));
+  connect(bou1.ports[1], chi.port_b2) annotation (Line(points={{4,-126},{16,-126},
+          {16,-112},{26,-112}}, color={0,127,255}));
+  connect(chi.port_a2, boundary1.ports[1]) annotation (Line(points={{46,-112},{58,
+          -112},{58,-126},{64,-126}}, color={0,127,255}));
+  connect(heaPum.TSet, realExpression.y)
+    annotation (Line(points={{46,7},{56,7},{56,6},{65,6}}, color={0,0,127}));
+  connect(chi.TSet, realExpression1.y) annotation (Line(points={{24,-97},{18,-97},
+          {18,-94},{13,-94}}, color={0,0,127}));
+  connect(HDem, division.u1)
+    annotation (Line(points={{0,100},{0,61.6},{30,61.6}}, color={0,0,127}));
+  connect(division.y, boundary.m_flow_in) annotation (Line(points={{53,55},{96,55},
+          {96,32},{88,32}}, color={0,0,127}));
+  connect(realExpression2.y, division.u2) annotation (Line(points={{21,48},{26,48},
+          {26,48.4},{30,48.4}}, color={0,0,127}));
+  connect(realExpression3.y, division1.u2) annotation (Line(points={{23,-164},{26,
+          -164},{26,-164},{30,-164},{30,-163.6},{32,-163.6}}, color={0,0,127}));
+  connect(division1.y, boundary1.m_flow_in) annotation (Line(points={{55,-157},{
+          92,-157},{92,-118},{86,-118}}, color={0,0,127}));
+  connect(CDem, division1.u1) annotation (Line(points={{40,100},{40,80},{98,80},
+          {98,-172},{26,-172},{26,-150.4},{32,-150.4}}, color={0,0,127}));
+  connect(realExpression5.y, division2.u2) annotation (Line(points={{23,-34},{16,
+          -34},{16,-33.6},{10,-33.6}}, color={0,0,127}));
+  connect(division2.y, pum_hea.m_flow_in)
+    annotation (Line(points={{-13,-27},{-34,-27},{-34,-20}}, color={0,0,127}));
+  connect(realExpression7.y, division3.u2) annotation (Line(points={{-37,-168},{
+          -54,-168},{-54,-167.6},{-56,-167.6}}, color={0,0,127}));
+  connect(division3.y, pumcoo.m_flow_in) annotation (Line(points={{-79,-161},{-88,
+          -161},{-88,-120},{-50,-120},{-50,-112}}, color={0,0,127}));
+  connect(sum1.y, P)
+    annotation (Line(points={{-39,70},{-36,70},{-36,100}}, color={0,0,127}));
+  connect(heaPum.P, sum1.u[1]) annotation (Line(points={{23,-2},{-70,-2},{-70,68.5},
+          {-62,68.5}}, color={0,0,127}));
+  connect(pum_hea.P, sum1.u[2]) annotation (Line(points={{-23,-17},{-18,-17},{-18,
+          -2},{-70,-2},{-70,69.5},{-62,69.5}}, color={0,0,127}));
+  connect(chi.P, sum1.u[3]) annotation (Line(points={{47,-106},{60,-106},{60,-48},
+          {-70,-48},{-70,70.5},{-62,70.5}}, color={0,0,127}));
+  connect(pumcoo.P, sum1.u[4]) annotation (Line(points={{-39,-109},{-22,-109},{-22,
+          -74},{-70,-74},{-70,71.5},{-62,71.5}}, color={0,0,127}));
+  connect(division3.u1, chi.QCon_flow) annotation (Line(points={{-56,-154.4},{16,
+          -154.4},{16,-134},{52,-134},{52,-97},{47,-97}}, color={0,0,127}));
+  connect(heaPum.QEva_flow, division2.u1) annotation (Line(points={{23,-11},{16,
+          -11},{16,-20.4},{10,-20.4}}, color={0,0,127}));
+  connect(temperature_cold.port_a, heaPum.port_b2) annotation (Line(points={{72,
+          -42},{78,-42},{78,-8},{44,-8}}, color={0,127,255}));
+  connect(temperature_cold.port_b, port_b)
+    annotation (Line(points={{52,-42},{-100,-42}}, color={0,127,255}));
+  connect(chi.port_b1, temperature_warm.port_a)
+    annotation (Line(points={{46,-100},{64,-100}}, color={0,127,255}));
+  connect(temperature_warm.port_b, port_a) annotation (Line(points={{84,-100},{
+          92,-100},{92,-60},{-80,-60},{-80,40},{-100,40}}, color={0,127,255}));
+  annotation (Documentation(info="<html>
+  <p>Models a consumer with a deterministic heat demand and cool demand. Carnot heat pumps are used for meeting the demand, using the network as a source for the heating demand and using the network
+  as a sink for the cooling demand. Decentral pumps are used.</p>
+</html>", revisions="<html>
+<ul>
+<li>November 8, 2018 by Felix Bünning:
+<br/>First implementation</li>
+</ul>
+</html>"),
+    Diagram(coordinateSystem(extent={{-100,-200},{100,100}}, initialScale=0.1)),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}}, initialScale=0.1),
+        graphics={
+        Rectangle(
+          extent={{-48,60},{88,-58}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={95,95,95},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-38,54},{76,36}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,48},{88,40}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-26,36},{-22,-4}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-38,54},{76,36}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,50},{88,40}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{16,40},{88,50}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={255,0,0},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{-24,0},{-34,-12},{-14,-12},{-24,0}},
+          lineColor={0,0,0},
+          smooth=Smooth.None,
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{-24,0},{-34,10},{-14,10},{-24,0}},
+          lineColor={0,0,0},
+          smooth=Smooth.None,
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-26,36},{-22,10}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-26,-12},{-22,-54}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{56,36},{60,-54}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{36,20},{80,-22}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{58,20},{40,-12},{76,-12},{58,20}},
+          lineColor={0,0,0},
+          smooth=Smooth.None,
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-38,-38},{76,-56}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,-42},{88,-52}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,-52},{16,-42}},
+          lineColor={0,0,127},
+          pattern=LinePattern.None,
+          fillColor={0,0,127},
+          fillPattern=FillPattern.Solid)}));
+end ConsumerBidirectional;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/ConsumerBidirectionalStorage.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/ConsumerBidirectionalStorage.mo
@@ -1,0 +1,312 @@
+﻿within IBPSAdestest.Consumer;
+model ConsumerBidirectionalStorage
+  "Basic consumer model for DesTest with a fixed temperature drop, decentralized pump and ideal mass flow control"
+  extends IBPSAdestest.Consumer.BaseClasses.EndNode_twoport;
+
+  parameter Modelica.SIunits.TemperatureDifference deltaT=4
+    "Desired temperature difference between warm and cold temperature line";
+
+  parameter Modelica.SIunits.Temperature T_sup_coo=273.15+10
+    "Supply temperature cooling (building side)";
+
+  parameter Modelica.SIunits.Temperature T_ret_coo=273.15+15
+    "Return temperature cooling (building side)";
+
+  parameter Modelica.SIunits.Temperature T_sup_hea=273.15+35
+    "Supply temperature heating (building side)";
+
+  parameter Modelica.SIunits.Temperature T_ret_hea=273.15+25
+    "Return temperature heating (building side)";
+
+  parameter Real eta_chi=0.3
+    "Carnot efficiency chiller";
+
+  parameter Real eta_hea=0.3
+    "Carnot efficiency heat pump";
+
+  parameter Modelica.SIunits.HeatFlowRate Q_hea_nominal=10000
+    "Nominal heat flow for heating";
+
+  parameter Modelica.SIunits.HeatFlowRate Q_coo_nominal=10000
+    "Nominal heat flow for cooling (positive)";
+
+  parameter Modelica.SIunits.Pressure dp_nominal(displayUnit="Pa")=10000
+    "Pressure difference at nominal flow rate (for each flow leg)";
+
+  Modelica.Blocks.Interfaces.RealInput HDem "Control input" annotation (
+      Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={0,100})));
+
+  Modelica.Blocks.Interfaces.RealInput CDem "Control input" annotation (
+      Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={40,100})));
+  IBPSA.Fluid.Movers.FlowControlled_m_flow pum_hea(
+                                               redeclare package Medium =
+        Medium,
+    m_flow_nominal=Q_hea_nominal/(deltaT*4.182),
+    addPowerToMedium=false,
+    T_start=289.15,
+    use_inputFilter=false)
+    annotation (Placement(transformation(extent={{-44,2},{-24,-18}})));
+  IBPSA.Fluid.Movers.FlowControlled_m_flow pumcoo(
+                                               redeclare package Medium =
+        Medium,
+    addPowerToMedium=false,
+    use_inputFilter=false,
+    T_start=285.15,
+    m_flow_nominal=Q_coo_nominal/(deltaT*4.182))
+    annotation (Placement(transformation(extent={{-60,-90},{-40,-110}})));
+  IBPSA.Fluid.HeatPumps.Carnot_TCon heaPum(
+    redeclare package Medium1 = Medium,
+    redeclare package Medium2 = Medium,
+    etaCarnot_nominal=eta_hea,
+    QCon_flow_nominal=Q_hea_nominal,
+    dTEva_nominal=-deltaT,
+    dp1_nominal=dp_nominal,
+    dp2_nominal=dp_nominal,
+    dTCon_nominal=T_sup_hea - T_ret_hea,
+    T2_start=285.15)
+    annotation (Placement(transformation(extent={{44,-12},{24,8}})));
+  IBPSA.Fluid.Chillers.Carnot_TEva chi(
+    redeclare package Medium1 = Medium,
+    redeclare package Medium2 = Medium,
+    etaCarnot_nominal=eta_chi,
+    dTEva_nominal=T_sup_coo - T_ret_coo,
+    dTCon_nominal=deltaT,
+    dp1_nominal=dp_nominal,
+    dp2_nominal=dp_nominal,
+    QEva_flow_nominal=-Q_coo_nominal,
+    T1_start=289.15,
+    T2_start=283.15)
+    annotation (Placement(transformation(extent={{26,-116},{46,-96}})));
+  Modelica.Blocks.Sources.RealExpression realExpression(y=T_sup_hea)
+    annotation (Placement(transformation(extent={{86,-4},{66,16}})));
+  Modelica.Blocks.Sources.RealExpression realExpression1(y=T_sup_coo)
+    annotation (Placement(transformation(extent={{-8,-104},{12,-84}})));
+  Modelica.Blocks.Math.Division division2
+    annotation (Placement(transformation(extent={{8,-38},{-12,-16}})));
+  Modelica.Blocks.Sources.RealExpression realExpression5(y=-cp_default*(deltaT))
+    annotation (Placement(transformation(extent={{44,-44},{24,-24}})));
+  Modelica.Blocks.Math.Division division3
+    annotation (Placement(transformation(extent={{-58,-172},{-78,-150}})));
+  Modelica.Blocks.Sources.RealExpression realExpression7(y=cp_default*(deltaT))
+    annotation (Placement(transformation(extent={{-16,-178},{-36,-158}})));
+  Modelica.Blocks.Interfaces.RealOutput P annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-36,100})));
+  Modelica.Blocks.Math.Sum sum1(nin=4)
+    annotation (Placement(transformation(extent={{-60,60},{-40,80}})));
+  BaseClasses.Storage_controlled_heating storage_controlled_heating(
+    redeclare package Medium = Medium,
+    T_sup=T_sup_hea,
+    T_ret=T_ret_hea,
+    volume_tank=1000,
+    Q_nominal=20000)
+    annotation (Placement(transformation(extent={{32,32},{52,52}})));
+  Modelica.Blocks.Sources.RealExpression realExpression2(y=0)
+    annotation (Placement(transformation(extent={{84,54},{64,74}})));
+  BaseClasses.Storage_controlled_cooling storage_controlled_cooling(
+    redeclare package Medium = Medium,
+    T_sup=T_sup_coo,
+    T_ret=T_ret_coo,
+    volume_tank=1000,
+    Q_nominal=20000)
+    annotation (Placement(transformation(extent={{36,-164},{56,-144}})));
+  Modelica.Blocks.Sources.RealExpression realExpression3(y=0)
+    annotation (Placement(transformation(extent={{88,-142},{68,-122}})));
+equation
+  connect(heaPum.port_a2, pum_hea.port_b)
+    annotation (Line(points={{24,-8},{-24,-8}}, color={0,127,255}));
+  connect(heaPum.port_b2, port_b) annotation (Line(points={{44,-8},{74,-8},{74,-42},
+          {-100,-42}}, color={0,127,255}));
+  connect(pum_hea.port_a, port_a) annotation (Line(points={{-44,-8},{-80,-8},{-80,
+          40},{-100,40}}, color={0,127,255}));
+  connect(port_b, pumcoo.port_a) annotation (Line(points={{-100,-42},{-88,-42},{
+          -88,-100},{-60,-100}}, color={0,127,255}));
+  connect(pumcoo.port_b, chi.port_a1)
+    annotation (Line(points={{-40,-100},{26,-100}}, color={0,127,255}));
+  connect(chi.port_b1, port_a) annotation (Line(points={{46,-100},{74,-100},{74,
+          -60},{-80,-60},{-80,40},{-100,40}}, color={0,127,255}));
+  connect(heaPum.TSet, realExpression.y)
+    annotation (Line(points={{46,7},{56,7},{56,6},{65,6}}, color={0,0,127}));
+  connect(chi.TSet, realExpression1.y) annotation (Line(points={{24,-97},{18,-97},
+          {18,-94},{13,-94}}, color={0,0,127}));
+  connect(realExpression5.y, division2.u2) annotation (Line(points={{23,-34},{16,
+          -34},{16,-33.6},{10,-33.6}}, color={0,0,127}));
+  connect(division2.y, pum_hea.m_flow_in)
+    annotation (Line(points={{-13,-27},{-34,-27},{-34,-20}}, color={0,0,127}));
+  connect(realExpression7.y, division3.u2) annotation (Line(points={{-37,-168},{
+          -54,-168},{-54,-167.6},{-56,-167.6}}, color={0,0,127}));
+  connect(division3.y, pumcoo.m_flow_in) annotation (Line(points={{-79,-161},{-88,
+          -161},{-88,-120},{-50,-120},{-50,-112}}, color={0,0,127}));
+  connect(sum1.y, P)
+    annotation (Line(points={{-39,70},{-36,70},{-36,100}}, color={0,0,127}));
+  connect(heaPum.P, sum1.u[1]) annotation (Line(points={{23,-2},{-70,-2},{-70,68.5},
+          {-62,68.5}}, color={0,0,127}));
+  connect(pum_hea.P, sum1.u[2]) annotation (Line(points={{-23,-17},{-18,-17},{-18,
+          -2},{-70,-2},{-70,69.5},{-62,69.5}}, color={0,0,127}));
+  connect(chi.P, sum1.u[3]) annotation (Line(points={{47,-106},{60,-106},{60,-48},
+          {-70,-48},{-70,70.5},{-62,70.5}}, color={0,0,127}));
+  connect(pumcoo.P, sum1.u[4]) annotation (Line(points={{-39,-109},{-22,-109},{-22,
+          -74},{-70,-74},{-70,71.5},{-62,71.5}}, color={0,0,127}));
+  connect(division3.u1, chi.QCon_flow) annotation (Line(points={{-56,-154.4},{16,
+          -154.4},{16,-134},{52,-134},{52,-97},{47,-97}}, color={0,0,127}));
+  connect(heaPum.QEva_flow, division2.u1) annotation (Line(points={{23,-11},{16,
+          -11},{16,-20.4},{10,-20.4}}, color={0,0,127}));
+  connect(heaPum.port_b1, storage_controlled_heating.port_a) annotation (Line(
+        points={{24,4},{-4,4},{-4,46},{32,46}}, color={0,127,255}));
+  connect(heaPum.port_a1, storage_controlled_heating.port_b) annotation (Line(
+        points={{44,4},{52,4},{52,22},{18,22},{18,37.8},{32,37.8}}, color={0,
+          127,255}));
+  connect(storage_controlled_heating.QDem, HDem) annotation (Line(points={{42,
+          52},{42,66},{0,66},{0,100}}, color={0,0,127}));
+  connect(realExpression2.y, storage_controlled_heating.Control_m_flow)
+    annotation (Line(points={{63,64},{39,64},{39,52}}, color={0,0,127}));
+  connect(chi.port_b2, storage_controlled_cooling.port_a) annotation (Line(
+        points={{26,-112},{12,-112},{12,-150},{36,-150}}, color={0,127,255}));
+  connect(storage_controlled_cooling.port_b, chi.port_a2) annotation (Line(
+        points={{36,-158.2},{24,-158.2},{24,-158},{2,-158},{2,-122},{50,-122},{
+          50,-112},{46,-112}}, color={0,127,255}));
+  connect(CDem, storage_controlled_cooling.QDem) annotation (Line(points={{40,
+          100},{40,76},{94,76},{94,-140},{46,-140},{46,-144}}, color={0,0,127}));
+  connect(realExpression3.y, storage_controlled_cooling.Control_m_flow)
+    annotation (Line(points={{67,-132},{43,-132},{43,-144}}, color={0,0,127}));
+  annotation (Documentation(info="<html>
+  <p>Models a consumer with a deterministic heat demand and cool demand and water storage for both demands. Carnot heat pumps are used for meeting the demand, using the network as a source for the heating demand and using the network
+  as a sink for the cooling demand. Decentral pumps are used. Stratified tanks models are used as storage.</p>
+</html>", revisions="<html>
+<ul>
+<li>November 8, 2018 by Felix Bünning:
+<br/>First implementation</li>
+</ul>
+</html>"),
+    Diagram(coordinateSystem(extent={{-100,-200},{100,100}}, initialScale=0.1)),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}}, initialScale=0.1),
+        graphics={
+        Rectangle(
+          extent={{-48,60},{88,-58}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={95,95,95},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-38,54},{76,36}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,50},{88,40}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{16,40},{88,50}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={255,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-26,36},{-22,-4}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-38,54},{76,36}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,50},{88,40}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{16,40},{88,50}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={255,0,0},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{-24,0},{-34,-12},{-14,-12},{-24,0}},
+          lineColor={0,0,0},
+          smooth=Smooth.None,
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{-24,0},{-34,10},{-14,10},{-24,0}},
+          lineColor={0,0,0},
+          smooth=Smooth.None,
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-26,36},{-22,10}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-26,-12},{-22,-54}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{56,36},{60,-54}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{36,20},{80,-22}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{58,20},{40,-12},{76,-12},{58,20}},
+          lineColor={0,0,0},
+          smooth=Smooth.None,
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-38,-38},{76,-56}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,-42},{76,-52}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,-42},{88,-52}},
+          lineColor={0,0,255},
+          pattern=LinePattern.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-48,-52},{16,-42}},
+          lineColor={0,0,127},
+          pattern=LinePattern.None,
+          fillColor={0,0,127},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-4,20},{28,-20}},
+          lineColor={0,0,0},
+          fillColor={35,138,255},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-4,14},{28,24}},
+          lineColor={0,0,0},
+          fillColor={35,138,255},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-4,-24},{28,-14}},
+          lineColor={0,0,0},
+          fillColor={35,138,255},
+          fillPattern=FillPattern.Solid)}));
+end ConsumerBidirectionalStorage;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/Examples/ConsumerBidirectionalExample.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/Examples/ConsumerBidirectionalExample.mo
@@ -1,0 +1,168 @@
+﻿within IBPSAdestest.Consumer.Examples;
+model ConsumerBidirectionalExample
+  extends Modelica.Icons.Example;
+  replaceable package Medium = IBPSA.Media.Water "Medium model";
+
+  Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(
+    tableOnFile=true,
+    extrapolation=Modelica.Blocks.Types.Extrapolation.HoldLastPoint,
+    tableName="data",
+    columns=2:18,
+    fileName=Modelica.Utilities.Files.loadResource(
+        "modelica://IBPSAdestest/Resources/Data/DestestHeatDemand/heat_profiles.txt"))
+    annotation (Placement(transformation(extent={{0,32},{20,52}})));
+  IBPSAdestest.Consumer.ConsumerBidirectional
+    idealConsumerBidirectional_heating(
+    redeclare package Medium = Medium,
+    Q_hea_nominal=20000,
+    Q_coo_nominal=-20000)
+    annotation (Placement(transformation(extent={{60,0},{80,20}})));
+  IBPSAdestest.Consumer.ConsumerBidirectional
+    idealConsumerBidirectional_cooling(
+    redeclare package Medium = Medium,
+    Q_hea_nominal=20000,
+    Q_coo_nominal=-20000)
+    annotation (Placement(transformation(extent={{60,-40},{80,-20}})));
+public
+  Buildings.Fluid.FixedResistances.Pipe     Supply_5_b(
+    redeclare package Medium = Medium,
+    length=50,
+    m_flow_nominal=2,
+    thicknessIns=0.1,
+    lambdaIns=0.035,
+    T_start=289.15)
+    annotation (Placement(transformation(extent={{0,-2},{-12,10}})));
+public
+  Buildings.Fluid.FixedResistances.Pipe     Return_5_b(
+    redeclare package Medium = Medium,
+    length=50,
+    m_flow_nominal=2,
+    thicknessIns=0.1,
+    lambdaIns=0.035,
+    T_start=289.15)
+    annotation (Placement(transformation(extent={{-12,-28},{0,-16}})));
+public
+  Buildings.Fluid.FixedResistances.Pipe     Supply_5_b1(
+    redeclare package Medium = Medium,
+    length=50,
+    m_flow_nominal=2,
+    thicknessIns=0.1,
+    lambdaIns=0.035,
+    T_start=285.15)
+    annotation (Placement(transformation(extent={{0,16},{-12,28}})));
+public
+  Buildings.Fluid.FixedResistances.Pipe     Return_5_b1(
+    redeclare package Medium = Medium,
+    length=50,
+    m_flow_nominal=2,
+    thicknessIns=0.1,
+    lambdaIns=0.035,
+    T_start=285.15)
+    annotation (Placement(transformation(extent={{-12,-48},{0,-36}})));
+  Modelica.Blocks.Sources.RealExpression realExpression(y=16 + 273.15)
+    annotation (Placement(transformation(extent={{-74,82},{-54,102}})));
+  Modelica.Blocks.Sources.RealExpression realExpression1(y=12 + 273.15)
+    annotation (Placement(transformation(extent={{-100,82},{-80,102}})));
+  Modelica.Blocks.Sources.RealExpression realExpression2(y=0)
+    annotation (Placement(transformation(extent={{20,82},{40,102}})));
+  IBPSA.Fluid.Sources.FixedBoundary bou(          redeclare package Medium =
+        Medium, nPorts=1)
+    annotation (Placement(transformation(extent={{-80,-70},{-60,-50}})));
+  Modelica.Fluid.Sensors.Temperature temperature_cold(redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-102,50},{-82,70}})));
+  Modelica.Fluid.Sensors.Temperature temperature_warm(redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-36,50},{-16,70}})));
+  Buildings.Experimental.DistrictHeatingCooling.Plants.Ideal_T ideal_T(
+      redeclare package Medium = Medium, m_flow_nominal=2)
+    annotation (Placement(transformation(extent={{-72,40},{-52,60}})));
+  Modelica.Fluid.Sensors.TemperatureTwoPort temperature_cold_consumerCooling(
+      redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{46,-76},{26,-56}})));
+  Modelica.Fluid.Sensors.TemperatureTwoPort temperature_warm_consumerCooling(
+      redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{30,-32},{50,-12}})));
+  Modelica.Blocks.Math.Add add
+    annotation (Placement(transformation(extent={{38,64},{58,84}})));
+  Modelica.Blocks.Sources.Sine sine(
+    amplitude=6000,
+    offset=0,
+    freqHz=0.00001)
+    annotation (Placement(transformation(extent={{0,66},{20,86}})));
+  IBPSA.Utilities.Math.SmoothMax smoothMax(deltaX=0.1)   annotation (Placement(
+        transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={70,38})));
+equation
+  connect(combiTimeTable.y[2], idealConsumerBidirectional_cooling.CDem)
+    annotation (Line(points={{21,42},{28,42},{28,26},{90,26},{90,-12},{74,-12},
+          {74,-20}},                                                      color=
+         {0,0,127}));
+  connect(realExpression2.y, idealConsumerBidirectional_heating.CDem)
+    annotation (Line(points={{41,92},{74,92},{74,20}}, color={0,0,127}));
+  connect(realExpression2.y, idealConsumerBidirectional_cooling.HDem)
+    annotation (Line(points={{41,92},{88,92},{88,-8},{70,-8},{70,-20}}, color={0,
+          0,127}));
+  connect(temperature_warm.port, ideal_T.port_b) annotation (Line(points={{-26,50},
+          {-52,50}},                   color={238,46,47}));
+  connect(temperature_cold.port, ideal_T.port_a) annotation (Line(points={{-92,50},
+          {-72,50}},                    color={0,127,255}));
+  connect(ideal_T.TSetHea, realExpression.y) annotation (Line(points={{-74,58},
+          {-74,76},{-48,76},{-48,92},{-53,92}},color={0,0,127}));
+  connect(ideal_T.TSetCoo, realExpression1.y) annotation (Line(points={{-74,54},
+          {-78,54},{-78,82},{-78,82},{-78,92},{-79,92}}, color={0,0,127}));
+  connect(idealConsumerBidirectional_cooling.port_b,
+    temperature_cold_consumerCooling.port_a) annotation (Line(points={{60,-34.2},
+          {54,-34.2},{54,-66},{46,-66}}, color={0,127,255}));
+  connect(idealConsumerBidirectional_cooling.port_a,
+    temperature_warm_consumerCooling.port_b) annotation (Line(points={{60,-26},{
+          56,-26},{56,-22},{50,-22}}, color={238,46,47}));
+  connect(idealConsumerBidirectional_heating.HDem, smoothMax.y)
+    annotation (Line(points={{70,20},{70,27}},         color={0,0,127}));
+  connect(smoothMax.u1, add.y) annotation (Line(points={{64,50},{64,74},{59,74}},
+                    color={0,0,127}));
+  connect(smoothMax.u2, realExpression2.y) annotation (Line(points={{76,50},{76,
+          50},{76,76},{76,76},{76,92},{41,92}}, color={0,0,127}));
+  connect(Return_5_b.port_a, Supply_5_b.port_b) annotation (Line(points={{-12,-22},
+          {-38,-22},{-38,4},{-12,4}}, color={238,46,47}));
+  connect(Return_5_b.port_b, Supply_5_b.port_a) annotation (Line(points={{0,-22},
+          {10,-22},{10,4},{0,4}}, color={238,46,47}));
+  connect(temperature_warm_consumerCooling.port_a, Return_5_b.port_b)
+    annotation (Line(points={{30,-22},{0,-22}}, color={238,46,47}));
+  connect(idealConsumerBidirectional_heating.port_a, Supply_5_b.port_a)
+    annotation (Line(points={{60,14},{52,14},{52,4},{0,4}}, color={238,46,47}));
+  connect(Supply_5_b.port_b, ideal_T.port_b) annotation (Line(points={{-12,4},{-40,
+          4},{-40,50},{-52,50}}, color={238,46,47}));
+  connect(Return_5_b1.port_a, Supply_5_b1.port_b) annotation (Line(points={{-12,
+          -42},{-46,-42},{-46,22},{-12,22}}, color={0,127,255}));
+  connect(Return_5_b1.port_b, Supply_5_b1.port_a) annotation (Line(points={{0,-42},
+          {18,-42},{18,22},{0,22}}, color={0,127,255}));
+  connect(temperature_cold_consumerCooling.port_b, Return_5_b1.port_b)
+    annotation (Line(points={{26,-66},{10,-66},{10,-42},{0,-42}},
+        color={0,127,255}));
+  connect(idealConsumerBidirectional_heating.port_b, Supply_5_b1.port_a)
+    annotation (Line(points={{60,5.8},{48,5.8},{48,6},{44,6},{44,22},{0,22}},
+        color={0,127,255}));
+  connect(Return_5_b1.port_a, ideal_T.port_a) annotation (Line(points={{-12,-42},
+          {-76,-42},{-76,50},{-72,50}}, color={0,127,255}));
+  connect(bou.ports[1], Return_5_b1.port_a) annotation (Line(points={{-60,-60},
+          {-14,-60},{-14,-42},{-12,-42}},color={0,127,255}));
+  connect(add.u2, combiTimeTable.y[1]) annotation (Line(points={{36,68},{28,68},
+          {28,42},{21,42}}, color={0,0,127}));
+  connect(sine.y, add.u1) annotation (Line(points={{21,76},{32,76},{32,80},{36,
+          80}}, color={0,0,127}));
+  annotation (Documentation(info="<html>
+<p>
+Example of <a href=\"modelica://IBPSAdestest.Consumer.ConsumerBidirectional\">ConsumerBidirectional</a> model using data from the DesTest building heat demand exercise. 
+</p>
+</html>", revisions="<html>
+<ul>
+<li>November 8, 2018, by Felix Bünning:
+<br/>First implementation</li>
+</ul>
+</html>"),
+    Icon(coordinateSystem(preserveAspectRatio=false)),
+    Diagram(coordinateSystem(preserveAspectRatio=false)));
+end ConsumerBidirectionalExample;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/Examples/ConsumerBidirectionalStorageExample.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/Examples/ConsumerBidirectionalStorageExample.mo
@@ -1,0 +1,168 @@
+﻿within IBPSAdestest.Consumer.Examples;
+model ConsumerBidirectionalStorageExample
+  extends Modelica.Icons.Example;
+  replaceable package Medium = IBPSA.Media.Water "Medium model";
+
+  Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(
+    tableOnFile=true,
+    extrapolation=Modelica.Blocks.Types.Extrapolation.HoldLastPoint,
+    tableName="data",
+    columns=2:18,
+    fileName=Modelica.Utilities.Files.loadResource(
+        "modelica://IBPSAdestest/Resources/Data/DestestHeatDemand/heat_profiles.txt"))
+    annotation (Placement(transformation(extent={{0,32},{20,52}})));
+  IBPSAdestest.Consumer.ConsumerBidirectionalStorage
+    idealConsumerBidirectional_heating(
+    redeclare package Medium = Medium,
+    Q_hea_nominal=20000,
+    Q_coo_nominal=20000)
+    annotation (Placement(transformation(extent={{60,-2},{80,18}})));
+  IBPSAdestest.Consumer.ConsumerBidirectionalStorage
+    idealConsumerBidirectional_cooling(
+    redeclare package Medium = Medium,
+    Q_hea_nominal=20000,
+    Q_coo_nominal=20000)
+    annotation (Placement(transformation(extent={{60,-38},{80,-18}})));
+public
+  Buildings.Fluid.FixedResistances.Pipe     Supply_5_b(
+    redeclare package Medium = Medium,
+    length=50,
+    m_flow_nominal=2,
+    thicknessIns=0.1,
+    lambdaIns=0.035,
+    T_start=289.15)
+    annotation (Placement(transformation(extent={{0,-2},{-12,10}})));
+public
+  Buildings.Fluid.FixedResistances.Pipe     Return_5_b(
+    redeclare package Medium = Medium,
+    length=50,
+    m_flow_nominal=2,
+    thicknessIns=0.1,
+    lambdaIns=0.035,
+    T_start=289.15)
+    annotation (Placement(transformation(extent={{-12,-30},{0,-18}})));
+public
+  Buildings.Fluid.FixedResistances.Pipe     Supply_5_b1(
+    redeclare package Medium = Medium,
+    length=50,
+    m_flow_nominal=2,
+    thicknessIns=0.1,
+    lambdaIns=0.035,
+    T_start=285.15)
+    annotation (Placement(transformation(extent={{0,16},{-12,28}})));
+public
+  Buildings.Fluid.FixedResistances.Pipe     Return_5_b1(
+    redeclare package Medium = Medium,
+    length=50,
+    m_flow_nominal=2,
+    thicknessIns=0.1,
+    lambdaIns=0.035,
+    T_start=285.15)
+    annotation (Placement(transformation(extent={{-12,-48},{0,-36}})));
+  Modelica.Blocks.Sources.RealExpression realExpression(y=16 + 273.15)
+    annotation (Placement(transformation(extent={{-62,80},{-42,100}})));
+  Modelica.Blocks.Sources.RealExpression realExpression1(y=12 + 273.15)
+    annotation (Placement(transformation(extent={{-96,80},{-76,100}})));
+  Modelica.Blocks.Sources.RealExpression realExpression2(y=0)
+    annotation (Placement(transformation(extent={{20,82},{40,102}})));
+  IBPSA.Fluid.Sources.FixedBoundary bou(          redeclare package Medium =
+        Medium, nPorts=1)
+    annotation (Placement(transformation(extent={{-80,-70},{-60,-50}})));
+  Modelica.Fluid.Sensors.Temperature temperature_cold(redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-104,50},{-84,70}})));
+  Modelica.Fluid.Sensors.Temperature temperature_warm(redeclare package Medium =
+        Medium)
+    annotation (Placement(transformation(extent={{-32,50},{-12,70}})));
+  Buildings.Experimental.DistrictHeatingCooling.Plants.Ideal_T ideal_T(
+      redeclare package Medium = Medium, m_flow_nominal=2)
+    annotation (Placement(transformation(extent={{-72,40},{-52,60}})));
+  Modelica.Fluid.Sensors.TemperatureTwoPort temperature_cold_consumerCooling(
+      redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{50,-52},{30,-32}})));
+  Modelica.Fluid.Sensors.TemperatureTwoPort temperature_warm_consumerCooling(
+      redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{30,-34},{50,-14}})));
+  Modelica.Blocks.Math.Add add
+    annotation (Placement(transformation(extent={{42,60},{62,80}})));
+  Modelica.Blocks.Sources.Sine sine(
+    amplitude=6000,
+    offset=0,
+    freqHz=0.00001)
+    annotation (Placement(transformation(extent={{0,66},{20,86}})));
+  IBPSA.Utilities.Math.SmoothMax smoothMax(deltaX=0.1)   annotation (Placement(
+        transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={70,38})));
+equation
+  connect(combiTimeTable.y[2], idealConsumerBidirectional_cooling.CDem)
+    annotation (Line(points={{21,42},{42,42},{42,24},{88,24},{88,-10},{74,-10},
+          {74,-18}},                                                      color=
+         {0,0,127}));
+  connect(realExpression2.y, idealConsumerBidirectional_heating.CDem)
+    annotation (Line(points={{41,92},{74,92},{74,18}}, color={0,0,127}));
+  connect(realExpression2.y, idealConsumerBidirectional_cooling.HDem)
+    annotation (Line(points={{41,92},{88,92},{88,-8},{70,-8},{70,-18}}, color={0,
+          0,127}));
+  connect(temperature_warm.port, ideal_T.port_b) annotation (Line(points={{-22,50},
+          {-52,50}},                   color={238,46,47}));
+  connect(temperature_cold.port, ideal_T.port_a) annotation (Line(points={{-94,50},
+          {-72,50}},                    color={0,127,255}));
+  connect(ideal_T.TSetHea, realExpression.y) annotation (Line(points={{-74,58},{
+          -74,76},{-34,76},{-34,90},{-41,90}}, color={0,0,127}));
+  connect(ideal_T.TSetCoo, realExpression1.y) annotation (Line(points={{-74,54},
+          {-84,54},{-84,82},{-68,82},{-68,90},{-75,90}}, color={0,0,127}));
+  connect(idealConsumerBidirectional_cooling.port_b,
+    temperature_cold_consumerCooling.port_a) annotation (Line(points={{60,-32.2},
+          {54,-32.2},{54,-42},{50,-42}}, color={0,127,255}));
+  connect(idealConsumerBidirectional_cooling.port_a,
+    temperature_warm_consumerCooling.port_b)
+    annotation (Line(points={{60,-24},{50,-24}}, color={238,46,47}));
+  connect(idealConsumerBidirectional_heating.HDem, smoothMax.y)
+    annotation (Line(points={{70,18},{70,27}},         color={0,0,127}));
+  connect(smoothMax.u1, add.y) annotation (Line(points={{64,50},{64,60},{63,60},
+          {63,70}}, color={0,0,127}));
+  connect(smoothMax.u2, realExpression2.y) annotation (Line(points={{76,50},{76,
+          92},{41,92}},                         color={0,0,127}));
+  connect(Return_5_b.port_a, Supply_5_b.port_b) annotation (Line(points={{-12,-24},
+          {-30,-24},{-30,4},{-12,4}}, color={238,46,47}));
+  connect(Return_5_b.port_b, Supply_5_b.port_a) annotation (Line(points={{0,-24},
+          {14,-24},{14,4},{0,4}}, color={238,46,47}));
+  connect(temperature_warm_consumerCooling.port_a, Return_5_b.port_b)
+    annotation (Line(points={{30,-24},{0,-24}}, color={238,46,47}));
+  connect(idealConsumerBidirectional_heating.port_a, Supply_5_b.port_a)
+    annotation (Line(points={{60,12},{52,12},{52,4},{0,4}}, color={238,46,47}));
+  connect(Supply_5_b.port_b, ideal_T.port_b) annotation (Line(points={{-12,4},{-40,
+          4},{-40,50},{-52,50}}, color={238,46,47}));
+  connect(Return_5_b1.port_a, Supply_5_b1.port_b) annotation (Line(points={{-12,
+          -42},{-46,-42},{-46,22},{-12,22}}, color={0,127,255}));
+  connect(Return_5_b1.port_b, Supply_5_b1.port_a) annotation (Line(points={{0,-42},
+          {22,-42},{22,22},{0,22}}, color={0,127,255}));
+  connect(temperature_cold_consumerCooling.port_b, Return_5_b1.port_b)
+    annotation (Line(points={{30,-42},{0,-42}},                   color={0,127,255}));
+  connect(idealConsumerBidirectional_heating.port_b, Supply_5_b1.port_a)
+    annotation (Line(points={{60,3.8},{54,3.8},{54,10},{54,10},{54,16},{54,16},
+          {54,22},{0,22}},
+        color={0,127,255}));
+  connect(Return_5_b1.port_a, ideal_T.port_a) annotation (Line(points={{-12,-42},
+          {-76,-42},{-76,50},{-72,50}}, color={0,127,255}));
+  connect(bou.ports[1], Return_5_b1.port_a) annotation (Line(points={{-60,-60},
+          {-14,-60},{-14,-42},{-12,-42}},color={0,127,255}));
+  connect(add.u1, sine.y)
+    annotation (Line(points={{40,76},{21,76}}, color={0,0,127}));
+  connect(combiTimeTable.y[1], add.u2) annotation (Line(points={{21,42},{30,42},
+          {30,64},{40,64}}, color={0,0,127}));
+  annotation (Documentation(info="<html>
+<p>
+Example of <a href=\"modelica://IBPSAdestest.Consumer.ConsumerBidirectionalStorage\">ConsumerBidirectionalStorage</a> model using data from the DesTest building heat demand exercise. 
+</p>
+</html>", revisions="<html>
+<ul>
+<li>November 8, 2018, by Felix Bünning:
+<br/>First implementation</li>
+</ul>
+</html>"),
+    Icon(coordinateSystem(preserveAspectRatio=false)),
+    Diagram(coordinateSystem(preserveAspectRatio=false)));
+end ConsumerBidirectionalStorageExample;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/Examples/package.order
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/Examples/package.order
@@ -1,1 +1,3 @@
 IdealConsumerTwinExample
+ConsumerBidirectionalExample
+ConsumerBidirectionalStorageExample

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/package.order
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Consumer/package.order
@@ -1,3 +1,5 @@
 IdealConsumerTwin
+ConsumerBidirectional
+ConsumerBidirectionalStorage
 BaseClasses
 Examples

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Network/SupplyNetwork.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Network/SupplyNetwork.mo
@@ -2,22 +2,118 @@ within IBPSAdestest.Network;
 model SupplyNetwork "Only supply line is modelled"
   extends Modelica.Icons.Example;
   extends BaseClasses.BuildingLocationsDouble(
-    SimpleDistrict_2(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_3(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_1(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_4(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_5(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_6(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_8(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_7(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_10(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_11(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_9(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_12(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_16(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_15(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_14(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_13(deltaT=20, T_start=T_supply + 273.15));
+    SimpleDistrict_2(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_3(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_1(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_4(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_5(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_6(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_8(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_7(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_10(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_11(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_9(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_12(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_16(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_15(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_14(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_13(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20));
 
   package Medium1 = IBPSA.Media.Water "Medium model";
 
@@ -725,14 +821,12 @@ public
     annotation (Placement(transformation(extent={{160,-140},{180,-120}})));
   Modelica.Blocks.Continuous.Integrator integrator
     annotation (Placement(transformation(extent={{130,-140},{150,-120}})));
-  Modelica.Blocks.Math.Sum sum1(nin=16)
-    annotation (Placement(transformation(extent={{60,-160},{80,-140}})));
-  Modelica.Blocks.Math.Add add(k2=-1)
-    annotation (Placement(transformation(extent={{100,-160},{120,-140}})));
   Modelica.Blocks.Interfaces.RealOutput HeatLossesTotal
     annotation (Placement(transformation(extent={{160,-180},{180,-160}})));
   Modelica.Blocks.Continuous.Integrator integrator1
     annotation (Placement(transformation(extent={{130,-180},{150,-160}})));
+  Modelica.Blocks.Sources.RealExpression realExpression1(y=fixedTemperature.port.Q_flow)
+    annotation (Placement(transformation(extent={{74,-160},{94,-140}})));
 equation
   connect(combiTimeTable.y[2], SimpleDistrict_2.QDem) annotation (Line(points={{-119,
           -110},{-108,-110},{-108,-74},{-198,-74},{-198,170},{-170,170},{-170,160}},
@@ -1199,20 +1293,14 @@ equation
     annotation (Line(points={{151,-130},{170,-130}}, color={0,0,127}));
   connect(integrator.u, HeatInjection) annotation (Line(points={{128,-130},{108,
           -130},{108,-112},{170,-112}}, color={0,0,127}));
-  connect(combiTimeTable.y[1:16], sum1.u[:]) annotation (Line(points={{-119,-110},{-112,-110},
-          {-112,-110},{-108,-110},{-108,-150},{58,-150}}, color={0,0,127}));
   connect(HeatInjection, HeatInjection)
     annotation (Line(points={{170,-112},{170,-112}}, color={0,0,127}));
-  connect(add.u1, HeatInjection) annotation (Line(points={{98,-144},{96,-144},{96,
-          -144},{86,-144},{86,-112},{170,-112}}, color={0,0,127}));
-  connect(sum1.y, add.u2) annotation (Line(points={{81,-150},{86,-150},{86,-156},
-          {98,-156}}, color={0,0,127}));
-  connect(add.y, HeatLosses)
-    annotation (Line(points={{121,-150},{170,-150}}, color={0,0,127}));
   connect(integrator1.y, HeatLossesTotal)
     annotation (Line(points={{151,-170},{170,-170}}, color={0,0,127}));
   connect(integrator1.u, HeatLosses) annotation (Line(points={{128,-170},{124,-170},
           {124,-150},{170,-150}}, color={0,0,127}));
+  connect(realExpression1.y, HeatLosses)
+    annotation (Line(points={{95,-150},{170,-150}}, color={0,0,127}));
   annotation (Diagram(coordinateSystem(extent={{-180,-180},{180,180}})), Icon(
         coordinateSystem(extent={{-100,-100},{100,100}})));
 end SupplyNetwork;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Network/SupplyNetwork_DynamicPipe.mo
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Network/SupplyNetwork_DynamicPipe.mo
@@ -2,22 +2,118 @@ within IBPSAdestest.Network;
 model SupplyNetwork_DynamicPipe "Only supply line is modelled"
   extends Modelica.Icons.Example;
   extends BaseClasses.BuildingLocationsDouble(
-    SimpleDistrict_2(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_3(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_1(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_4(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_5(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_6(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_8(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_7(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_10(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_11(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_9(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_12(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_16(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_15(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_14(deltaT=20, T_start=T_supply + 273.15),
-    SimpleDistrict_13(deltaT=20, T_start=T_supply + 273.15));
+    SimpleDistrict_2(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_3(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_1(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_4(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_5(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_6(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_8(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_7(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_10(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_11(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_9(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_12(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_16(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_15(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_14(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20),
+    SimpleDistrict_13(           T_start=T_supply + 273.15,
+      m_flo_bypass=0.001,
+      pum(
+        energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        massDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
+        use_inputFilter=false),
+      deltaT=20));
 
   package Medium1 = IBPSA.Media.Water "Medium model";
   parameter Real pipeData[24,6]=DataFiles.readCSVmatrix(Buildings.BoundaryConditions.WeatherData.BaseClasses.getAbsolutePath("modelica://IBPSAdestest/Resources/Data/DestestPipeData/Pipe data wo names.csv"));
@@ -644,14 +740,12 @@ public
     annotation (Placement(transformation(extent={{160,-140},{180,-120}})));
   Modelica.Blocks.Continuous.Integrator integrator
     annotation (Placement(transformation(extent={{130,-140},{150,-120}})));
-  Modelica.Blocks.Math.Sum sum1(nin=16)
-    annotation (Placement(transformation(extent={{60,-160},{80,-140}})));
-  Modelica.Blocks.Math.Add add(k2=-1)
-    annotation (Placement(transformation(extent={{100,-160},{120,-140}})));
   Modelica.Blocks.Interfaces.RealOutput HeatLossesTotal
     annotation (Placement(transformation(extent={{160,-180},{180,-160}})));
   Modelica.Blocks.Continuous.Integrator integrator1
     annotation (Placement(transformation(extent={{130,-180},{150,-160}})));
+  Modelica.Blocks.Sources.RealExpression realExpression1(y=fixedTemperature.port.Q_flow)
+    annotation (Placement(transformation(extent={{74,-160},{94,-140}})));
 equation
   connect(combiTimeTable.y[2], SimpleDistrict_2.QDem) annotation (Line(points={{-119,
           -110},{-108,-110},{-108,-74},{-198,-74},{-198,170},{-170,170},{-170,160}},
@@ -1116,22 +1210,16 @@ equation
     annotation (Line(points={{151,-130},{170,-130}}, color={0,0,127}));
   connect(integrator.u, HeatInjection) annotation (Line(points={{128,-130},{108,
           -130},{108,-112},{170,-112}}, color={0,0,127}));
-  connect(combiTimeTable.y[1:16], sum1.u[:]) annotation (Line(points={{-119,-110},{-112,-110},
-          {-112,-110},{-108,-110},{-108,-150},{58,-150}}, color={0,0,127}));
   connect(HeatInjection, HeatInjection)
     annotation (Line(points={{170,-112},{170,-112}}, color={0,0,127}));
-  connect(add.u1, HeatInjection) annotation (Line(points={{98,-144},{96,-144},{96,
-          -144},{86,-144},{86,-112},{170,-112}}, color={0,0,127}));
-  connect(sum1.y, add.u2) annotation (Line(points={{81,-150},{86,-150},{86,-156},
-          {98,-156}}, color={0,0,127}));
-  connect(add.y, HeatLosses)
-    annotation (Line(points={{121,-150},{170,-150}}, color={0,0,127}));
   connect(integrator1.y, HeatLossesTotal)
     annotation (Line(points={{151,-170},{170,-170}}, color={0,0,127}));
   connect(integrator1.u, HeatLosses) annotation (Line(points={{128,-170},{124,-170},
           {124,-150},{170,-150}}, color={0,0,127}));
   connect(bou.ports[1], hea.port_a) annotation (Line(points={{-30,-140},{-18,
           -140},{-18,-120},{-10,-120}}, color={0,127,255}));
+  connect(realExpression1.y, HeatLosses)
+    annotation (Line(points={{95,-150},{170,-150}}, color={0,0,127}));
   annotation (Diagram(coordinateSystem(extent={{-180,-180},{180,180}})), Icon(
         coordinateSystem(extent={{-100,-100},{100,100}})));
 end SupplyNetwork_DynamicPipe;

--- a/wp_3_2_destest/Modelica/IBPSAdestest/Network/package.order
+++ b/wp_3_2_destest/Modelica/IBPSAdestest/Network/package.order
@@ -1,3 +1,4 @@
 SupplyNetwork
-BaseClasses
 SupplyNetwork_numerical
+SupplyNetwork_DynamicPipe
+BaseClasses


### PR DESCRIPTION
The Destest network models were updated: 
- heat losses in the pipes are calculated differently
- filter in pumps was disabled, pumps were set to steady state

Bidirectional substations for additional Destest scenarios were added:
- substation for heating and cooling demand with carnot vapor cycles
- substations with and without thermal storage for heating and cooling
- example models for both substations